### PR TITLE
Fix style of Log In link in sidebar

### DIFF
--- a/sympy-live/css/live-core.css
+++ b/sympy-live/css/live-core.css
@@ -172,8 +172,8 @@
 
 /* Sidebar card-specific styling */
 
-.sidebar_card h3:first-child {
-  cursor: pointer;
+.sidebar_card h3:first-child > a {
+  display: block;
 }
 
 .sidebar_card .clickable_top h3:first-child:before {


### PR DESCRIPTION
Before, the link container was assigned a pointer ("hand") cursor, despite nothing happening when it was actually clicked.

This change expands the area that is actually clickable, which automatically changes the cursor to pointer mode.

This issue was identified by @Abhishek-IOT in https://github.com/sympy/sympy-live/issues/178.