### PR TITLE
Fixes to mobile menu logic to work on window resize

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -1,27 +1,43 @@
 // JavaScript for the main SymPy website. See /static/sympy-live/javascript
 // for SymPy Live's code.
 $(document).ready(function() {
-    if (screen.width <= 767) {
-        var el = $('#main-navigation ul');
-        var visible = false;
-        el.hide();
 
-        $('#mobile-menu').click(function() {
-            $(this).toggleClass('active');
+    // State variable that determines whether menu is visible or not on mobile
+    var visibleMobileMenu = false;
 
-            if (visible) {
-                el.css('opacity', 0);
-                setTimeout(function() {
-                    el.hide();
-                }, 300);
-                visible = false;
+    // Toggle `#main-navigation ul` element visibility on mobile
+    $('#mobile-menu').click(function() {
+        var menuEl = $('#main-navigation ul');
+        $(this).toggleClass('active');
+        if (visibleMobileMenu) {
+            menuEl.css('opacity', 0);
+            setTimeout(function() {
+                menuEl.hide();
+            }, 300);
+            visibleMobileMenu = false;
+        } else {
+            menuEl.show().css('opacity', 1);
+            visibleMobileMenu = true;
+        }
+    });
+
+    // Determines whether to the `#main-navigation ul` element is visible or not
+    function show_responsive_menu() {
+        var menuEl = $('#main-navigation ul');
+        if (window.innerWidth <= 767) {                                // mobile            
+            if (visibleMobileMenu) {
+                menuEl.show().css('opacity', 1);
+            } else {
+                menuEl.hide();
             }
-            else {
-                el.show().css('opacity', 1);
-                visible = true;
-            }
-        });
+        } else {                                                      // desktop
+            menuEl.show().css('opacity', 1);
+        }
     }
+    show_responsive_menu();
+    window.onresize = function() {
+        show_responsive_menu();
+    };
 
     var examples = [
         "integrate(1 / (1 + x^2))",


### PR DESCRIPTION
RE: Issue noticed in https://github.com/sympy/sympy.github.com/pull/169#issuecomment-1095545758 when the mobile menu gets "stuck" in the visible state when user resizes browse window (e.g. website is loaded with wide viewport, then resized to get a mobile preview).

Problems and solutions:
1. the previous logic of the js code used `screen.width` (device width) which is not the same as window width (`window.innerWidth`).
   - FIX1 = use `window.innerWidth` instead of `screen.width`
2. the previous js logic assumed the decision "mobile" or "desktop" is made once on `$(document).ready`
   - FIX2 = add a `window.onresize` handler that runs the mobile-or-deskop logic every time window is resized

